### PR TITLE
[needscomment] add reference to the original vgpu presentation

### DIFF
--- a/mdev.ddd
+++ b/mdev.ddd
@@ -25,3 +25,13 @@ base_slide "The mdev framework",
         diagram_small "#2A4", -300, 350, 450, 50, "SysFS for mdev"
         diagram_small "#777",  430, 350, 250, 50, "IOMMU UAPI"
         diagram_small "#777",  170, 350, 250, 50, "VFIO UAPI"
+
+base_slide "The mdev framework presentation",
+
+    text_box 0, 0, 700, 200,
+        font_size 16
+        align 50%
+        vertical_align 50%
+        paragraph "more details in talk"
+        paragraph "vGPU on KVM - A VFIO Based Framework @ KVM Forum '16 Toronto"
+        paragraph "http://www.linux-kvm.org/images/5/59/02x03-Neo_Jia_and_Kirti_Wankhede-vGPU_on_KVM-A_VFIO_based_Framework.pdf"


### PR DESCRIPTION
People might be asking for more information, this is the go-to talk
for that.

...
Would this be the right way of doing that, or does the template have something defined for referencing other talks?